### PR TITLE
Do not make Emacs behave well in the terminal

### DIFF
--- a/home/doom/init.el
+++ b/home/doom/init.el
@@ -108,7 +108,7 @@
 
        :os
        (:if IS-MAC macos)  ; improve compatibility with macOS
-       tty                 ; improve the terminal Emacs experience
+       ;;tty               ; improve the terminal Emacs experience
 
        :lang
        ;;agda              ; types of types of types of types...


### PR DESCRIPTION
If I am on a graphical machine, I am probably using graphical Emacs
anyway - if I am using TUI Emacs, then probably I am on a remote
machine, and I want to be able to copy/paste via the terminal, because I
will not be able to copy/paste via the clipboard.