### PR TITLE
Fix Anastasia's ZFS configuration

### DIFF
--- a/nixos/_common/both/dns-server.nix
+++ b/nixos/_common/both/dns-server.nix
@@ -246,14 +246,14 @@ in
           )}
         '';
         serviceConfig.Type = "oneshot";
+        requires = [ "network-online.target" ]; # fails if network isn't online
+        after = [ "network-online.target" ]; # only runs after network is online
+        wantedBy = [ "network-online.target" ]; # runs when network comes online
       };
 
       systemd.timers.update-dns-with-public-ip = {
         wantedBy = [ "timers.target" ];
-        timerConfig = {
-          OnCalendar = "*:0/1";
-          OnBootSec = "0";
-        };
+        timerConfig.OnCalendar = "*:0/1"; # every minute
       };
     })
   ];

--- a/nixos/anastasia/hardware.nix
+++ b/nixos/anastasia/hardware.nix
@@ -135,6 +135,13 @@ in
     ## we don't want a long interruption for the important data, and we don't
     ## mind as much for medias.
 
+    ## NOTE: We use legacy mountpoints so that ZFS does not automount these
+    ## datasets itself. Instead, systemd handles mounting via the usual mount
+    ## units, which avoids a conflict between the two at boot.
+    ##
+    ## In disko, this is `datasets.<dataset>.options.mountpoint = "legacy"`, and
+    ## in ZFS, this is `zfs set mountpoint=legacy <dataset>`.
+
     zpool.important = {
       type = "zpool";
       mode = "mirror";
@@ -144,10 +151,12 @@ in
         "pictures" = {
           type = "zfs_fs";
           mountpoint = "/data/pictures";
+          options.mountpoint = "legacy";
         };
         "services" = {
           type = "zfs_fs";
           mountpoint = "/data/services";
+          options.mountpoint = "legacy";
         };
       };
     };
@@ -161,6 +170,7 @@ in
         "medias" = {
           type = "zfs_fs";
           mountpoint = "/data/medias";
+          options.mountpoint = "legacy";
         };
       };
     };

--- a/nixos/anastasia/hardware.nix
+++ b/nixos/anastasia/hardware.nix
@@ -147,6 +147,12 @@ in
     ## In disko, this is `datasets.<dataset>.options.mountpoint = "legacy"`, and
     ## in ZFS, this is `zfs set mountpoint=legacy <dataset>`.
 
+    ## NOTE: In the event that a disk dies, we want the system to boot anyway,
+    ## which is possible since the system itself is not on ZFS. To achieve this,
+    ## we set `nofail` on the mount options of the datasets, which means that
+    ## the system will boot even if the datasets fail to mount, and we add a
+    ## `TimeoutStartSec` to the ZFS import services.
+
     zpool.important = {
       type = "zpool";
       mode = "mirror";
@@ -157,11 +163,13 @@ in
           type = "zfs_fs";
           mountpoint = "/data/pictures";
           options.mountpoint = "legacy";
+          mountOptions = [ "nofail" ];
         };
         "services" = {
           type = "zfs_fs";
           mountpoint = "/data/services";
           options.mountpoint = "legacy";
+          mountOptions = [ "nofail" ];
         };
       };
     };
@@ -176,8 +184,13 @@ in
           type = "zfs_fs";
           mountpoint = "/data/medias";
           options.mountpoint = "legacy";
+          mountOptions = [ "nofail" ];
         };
       };
     };
+
   };
+
+  systemd.services."zfs-import-important".serviceConfig.TimeoutStartSec = 60;
+  systemd.services."zfs-import-unimportant".serviceConfig.TimeoutStartSec = 60;
 }

--- a/nixos/anastasia/hardware.nix
+++ b/nixos/anastasia/hardware.nix
@@ -135,6 +135,11 @@ in
     ## we don't want a long interruption for the important data, and we don't
     ## mind as much for medias.
 
+    ## NOTE: A lot of ZFS-related Disko options only ever have an impact during
+    ## initial installation, and changing them will have no effect. We still set
+    ## them here for documentation purposes, but this might not actually be
+    ## entirely correct, and one needs to also apply the change manually to ZFS.
+
     ## NOTE: We use legacy mountpoints so that ZFS does not automount these
     ## datasets itself. Instead, systemd handles mounting via the usual mount
     ## units, which avoids a conflict between the two at boot.


### PR DESCRIPTION
Currently, Anastasia just doesn't boot most of the time because ZFS import fails. We strive to do two things:

- Actually fix the problem behind this failed import.
- Make it so ZFS problems don't prevent Anastasia from booting.