### PR TITLE
Let the kernel choose its console font

### DIFF
--- a/nixos/_common/laptop/timezone.nix
+++ b/nixos/_common/laptop/timezone.nix
@@ -11,7 +11,7 @@
 
   i18n.defaultLocale = "en_GB.UTF-8";
   console = {
-    font = "Lat2-Terminus16";
+    font = null; # let the kernel choose
     keyMap = "us";
   };
 }


### PR DESCRIPTION
This fixes:

```
systemd[1]: Starting Virtual Console Setup...
systemd-vconsole-setup[280]: setfont: ERROR setfont.c:435 kfont_load_font: Unable to find file: Lat2-Terminus16
systemd-vconsole-setup[274]: /nix/store/6zvnkhqk669qn4srr8q6rgcx4pmy7iby-kbd-2.9.0/bin/setfont failed with exit status 66.
systemd-vconsole-setup[274]: Configuration of first virtual console failed, ignoring remaining ones.
systemd[1]: systemd-vconsole-setup.service: Main process exited, code=exited, status=1/FAILURE
systemd[1]: systemd-vconsole-setup.service: Failed with result 'exit-code'.
systemd[1]: Failed to start Virtual Console Setup.
```