### PR TITLE
Clean the definition of machines up

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,7 +79,7 @@
 
           extraSpecialArgs = {
             inherit inputs;
-            inherit (self) machines;
+            machines = import ./machines.nix;
           };
 
           modules = [

--- a/home/packages/graphical.nix
+++ b/home/packages/graphical.nix
@@ -44,7 +44,7 @@ in
         picard
         nextcloud-client # needs to be here AND in `xdg.autostart`
         signal-desktop
-        texlive.combined.scheme-full
+        texliveFull
         thunderbird
         tor-browser
         vlc

--- a/machines.nix
+++ b/machines.nix
@@ -1,0 +1,67 @@
+let
+  inherit (builtins)
+    mapAttrs
+    listToAttrs
+    filter
+    attrNames
+    ;
+
+  filterAttrs =
+    f: x:
+    listToAttrs (
+      filter ({ name, value }: f name value) (
+        map (name: {
+          inherit name;
+          value = x.${name};
+        }) (attrNames x)
+      )
+    );
+
+  ## The prefix of the IPs used for the internal WireGuard network. It can be
+  ## anything within 10.x but we choose something fairly unique in the hope of
+  ## avoiding conflicts with other networks.
+  ##
+  wgIpPrefix = "10.187.93";
+
+  ## Some metadata for the machines of this configuration.
+  ##
+  all = mapAttrs (name: meta: meta // { inherit name; }) {
+    ahlaya = {
+      kind = "laptop";
+    };
+    anastasia = rec {
+      kind = "server";
+      localIp = "192.168.1.11"; # on the local network, in this case a home 192.168.* network
+      internalIndex = 1;
+      internalIp = "${wgIpPrefix}.${toString internalIndex}"; # on the internal WireGuard network
+      wgPublicKey = "ElfanRos88bHayCTJM9qhg1XPOM/egor8ShHoOXAz1c=";
+      cores = 2;
+    };
+    gromit = {
+      kind = "laptop";
+    };
+    helga = rec {
+      kind = "server";
+      ipv4 = "188.245.212.11";
+      ipv6 = "2a01:4f8:1c1c:42dc::1"; # in fact, we have the whole /64 subnet
+      internalIndex = 2;
+      internalIp = "${wgIpPrefix}.${toString internalIndex}";
+      wgPublicKey = "bWTTesse8keIrCO8MWmXFhhHcvwmn+s+DY2nHFi+tmw=";
+      cores = 2;
+    };
+    orianne = rec {
+      kind = "server";
+      ipv4 = "89.168.38.231";
+      internalIndex = 3;
+      internalIp = "${wgIpPrefix}.${toString internalIndex}";
+      wgPublicKey = "Gu3XXcxqxQDy+N1yFZ7fbJMpJWKOBJKeF95doHmQMT0=";
+      cores = 4;
+    };
+  };
+in
+
+{
+  inherit all wgIpPrefix;
+  laptops = filterAttrs (_: { kind, ... }: kind == "laptop") all;
+  servers = filterAttrs (_: { kind, ... }: kind == "server") all;
+}

--- a/machines.nix
+++ b/machines.nix
@@ -23,43 +23,69 @@ let
   ##
   wgIpPrefix = "10.187.93";
 
-  ## Some metadata for the machines of this configuration.
+  ## Some metadata for the machines of this configuration. Machines
+  ## can have a bunch of different IPs:
   ##
-  all = mapAttrs (name: meta: meta // { inherit name; }) {
+  ## - public IPs (fields `ipv4` and `ipv6`) are static IPs on the
+  ##   public network, eg. IPs given for a VM by a cloud provider
+  ##
+  ## - “local” IPs are IPs on the local network, for instance in a
+  ##   home 192.168.* network, or internally to a cloud provider
+  ##
+  ## - “internal” IPs are IPs in the WireGuard network that binds all
+  ##   machines together; it is derived from `wgIpPrefix` and the
+  ##   internal index of each machine.
+
+  makeAll = mapAttrs (
+    name: meta:
+    meta
+    // {
+      inherit name;
+    }
+    // (
+      if meta ? internalIndex then
+        { internalIp = "${wgIpPrefix}.${toString meta.internalIndex}"; }
+      else
+        { }
+    )
+  );
+
+  all = makeAll {
     ahlaya = {
       kind = "laptop";
     };
-    anastasia = rec {
+
+    anastasia = {
       kind = "server";
-      localIp = "192.168.1.11"; # on the local network, in this case a home 192.168.* network
+      localIp = "192.168.1.11";
       internalIndex = 1;
-      internalIp = "${wgIpPrefix}.${toString internalIndex}"; # on the internal WireGuard network
       wgPublicKey = "ElfanRos88bHayCTJM9qhg1XPOM/egor8ShHoOXAz1c=";
       cores = 2;
     };
+
     gromit = {
       kind = "laptop";
     };
-    helga = rec {
+
+    helga = {
       kind = "server";
       ipv4 = "188.245.212.11";
       ipv6 = "2a01:4f8:1c1c:42dc::1"; # in fact, we have the whole /64 subnet
       internalIndex = 2;
-      internalIp = "${wgIpPrefix}.${toString internalIndex}";
       wgPublicKey = "bWTTesse8keIrCO8MWmXFhhHcvwmn+s+DY2nHFi+tmw=";
       cores = 2;
     };
-    orianne = rec {
+
+    orianne = {
       kind = "server";
       ipv4 = "89.168.38.231";
       internalIndex = 3;
-      internalIp = "${wgIpPrefix}.${toString internalIndex}";
       wgPublicKey = "Gu3XXcxqxQDy+N1yFZ7fbJMpJWKOBJKeF95doHmQMT0=";
       cores = 4;
     };
   };
-in
 
+in
 {
   inherit all wgIpPrefix;
   laptops = filterAttrs (_: { kind, ... }: kind == "laptop") all;

--- a/nixos/flake-part.nix
+++ b/nixos/flake-part.nix
@@ -1,122 +1,31 @@
 {
   self,
   inputs,
+  lib,
   withSystem,
   ...
 }:
 
 let
-  inherit (inputs.nixpkgs.lib)
+  inherit (lib)
     mapAttrs
-    mapAttrs'
-    mkForce
-    nixosSystem
-    filterAttrs
     ;
 
-  ## The prefix of the IPs used for the internal WireGuard network. It can be
-  ## anything within 10.x but we choose something fairly unique in the hope of
-  ## avoiding conflicts with other networks.
-  ##
-  wgIpPrefix = "10.187.93";
+  machines = import ../machines.nix;
 
-  ## Some metadata for the machines of this configuration.
-  ##
-  all = mapAttrs (name: meta: meta // { inherit name; }) {
-    ahlaya = {
-      kind = "laptop";
-    };
-    anastasia = rec {
-      kind = "server";
-      localIp = "192.168.1.11"; # on the local network, in this case a home 192.168.* network
-      internalIndex = 1;
-      internalIp = "${wgIpPrefix}.${toString internalIndex}"; # on the internal WireGuard network
-      wgPublicKey = "ElfanRos88bHayCTJM9qhg1XPOM/egor8ShHoOXAz1c=";
-      cores = 2;
-    };
-    gromit = {
-      kind = "laptop";
-    };
-    helga = rec {
-      kind = "server";
-      ipv4 = "188.245.212.11";
-      ipv6 = "2a01:4f8:1c1c:42dc::1"; # in fact, we have the whole /64 subnet
-      internalIndex = 2;
-      internalIp = "${wgIpPrefix}.${toString internalIndex}";
-      wgPublicKey = "bWTTesse8keIrCO8MWmXFhhHcvwmn+s+DY2nHFi+tmw=";
-      cores = 2;
-    };
-    orianne = rec {
-      kind = "server";
-      ipv4 = "89.168.38.231";
-      internalIndex = 3;
-      internalIp = "${wgIpPrefix}.${toString internalIndex}";
-      wgPublicKey = "Gu3XXcxqxQDy+N1yFZ7fbJMpJWKOBJKeF95doHmQMT0=";
-      cores = 4;
-    };
-  };
-  machines = {
-    inherit all wgIpPrefix;
-    laptops = filterAttrs (_: { kind, ... }: kind == "laptop") all;
-    servers = filterAttrs (_: { kind, ... }: kind == "server") all;
-  };
-
-  ## The special arguments that we need to propagate throughout the whole
-  ## codebase and all the modules, specialised for the given machine.
-  ##
-  specialArgsFor = name: {
-    inherit inputs;
-    machines = machines // {
-      this = machines.all.${name};
-      otherLaptops = filterAttrs (otherName: _: otherName != name) machines.laptops;
-      otherServers = filterAttrs (otherName: _: otherName != name) machines.servers;
-    };
-  };
-
-  nixosModuleFor =
-    name:
-    (
-      { config, ... }:
-      {
-        imports = [
-          self.nixosModules.keys
-          self.nixosModules.secrets
-          self.nixosModules.${name}
-          inputs.home-manager.nixosModules.home-manager
-        ];
-
-        nixpkgs.pkgs = withSystem config.nixpkgs.hostPlatform.system ({ pkgs, ... }: pkgs);
-
-        home-manager = {
-          ## By default, Home Manager uses a private pkgs instance that is
-          ## configured via the `home-manager.users.<name>.nixpkgs` options.
-          ## The following option instead uses the global pkgs that is
-          ## configured via the system level nixpkgs options; This saves an
-          ## extra Nixpkgs evaluation, adds consistency, and removes the
-          ## dependency on `NIX_PATH`, which is otherwise used for importing
-          ## Nixpkgs.
-          useGlobalPkgs = true;
-
-          ## By default packages will be installed to `$HOME/.nix-profile` but
-          ## they can be installed to `/etc/profiles` if the following is
-          ## added to the system configuration. This option may become the
-          ## default value in the future.
-          useUserPackages = true;
-
-          sharedModules = [ self.homeModules.secrets ];
-
-          extraSpecialArgs = specialArgsFor name;
-        };
-
-        ## The default timeout for Home Manager services is 5 minutes. This is
-        ## extremely reasonable, except that we may compile all of Doom Emacs
-        ## in that time, so we need to bump it for all our HM users.
-        systemd.services = mapAttrs' (user: _: {
-          name = "home-manager-${user}";
-          value.serviceConfig.TimeoutStartSec = mkForce "20m";
-        }) config.home-manager.users;
-      }
-    );
+  inherit
+    (import ./nixosModuleFor.nix {
+      inherit
+        self
+        inputs
+        lib
+        withSystem
+        machines
+        ;
+    })
+    specialArgsFor
+    nixosModuleFor
+    ;
 
   nixops4ComponentFor = name: providers: {
     type = providers.local.exec;
@@ -148,12 +57,9 @@ in
     inputs.nixops4.modules.flake.default
   ];
 
-  ## FIXME: stop passing arguments via `self` like this
-  flake.machines = machines;
-
   flake.nixosConfigurations = mapAttrs (
     name: _:
-    nixosSystem {
+    inputs.nixpkgs.lib.nixosSystem {
       modules = [ (nixosModuleFor name) ];
       specialArgs = specialArgsFor name;
     }

--- a/nixos/flake-part.nix
+++ b/nixos/flake-part.nix
@@ -19,9 +19,9 @@ let
         self
         inputs
         lib
-        withSystem
         machines
         ;
+      pkgsFor = system: withSystem system ({ pkgs, ... }: pkgs);
     })
     specialArgsFor
     nixosModuleFor

--- a/nixos/nixosModuleFor.nix
+++ b/nixos/nixosModuleFor.nix
@@ -1,0 +1,77 @@
+{
+  self,
+  inputs,
+  lib,
+  withSystem,
+  machines,
+}:
+
+let
+  inherit (lib)
+    mapAttrs'
+    mkForce
+    filterAttrs
+    ;
+
+  ## The special arguments that we need to propagate throughout the whole
+  ## codebase and all the modules, specialised for the given machine.
+  ##
+  specialArgsFor = name: {
+    inherit inputs;
+    machines = machines // {
+      this = machines.all.${name};
+      otherLaptops = filterAttrs (otherName: _: otherName != name) machines.laptops;
+      otherServers = filterAttrs (otherName: _: otherName != name) machines.servers;
+    };
+  };
+
+  nixosModuleFor =
+    name:
+    (
+      { config, ... }:
+      {
+        imports = [
+          self.nixosModules.keys
+          self.nixosModules.secrets
+          self.nixosModules.${name}
+          inputs.home-manager.nixosModules.home-manager
+        ];
+
+        nixpkgs.pkgs = withSystem config.nixpkgs.hostPlatform.system ({ pkgs, ... }: pkgs);
+
+        home-manager = {
+          ## By default, Home Manager uses a private pkgs instance that is
+          ## configured via the `home-manager.users.<name>.nixpkgs` options.
+          ## The following option instead uses the global pkgs that is
+          ## configured via the system level nixpkgs options; This saves an
+          ## extra Nixpkgs evaluation, adds consistency, and removes the
+          ## dependency on `NIX_PATH`, which is otherwise used for importing
+          ## Nixpkgs.
+          useGlobalPkgs = true;
+
+          ## By default packages will be installed to `$HOME/.nix-profile` but
+          ## they can be installed to `/etc/profiles` if the following is
+          ## added to the system configuration. This option may become the
+          ## default value in the future.
+          useUserPackages = true;
+
+          sharedModules = [ self.homeModules.secrets ];
+
+          extraSpecialArgs = specialArgsFor name;
+        };
+
+        ## The default timeout for Home Manager services is 5 minutes. This is
+        ## extremely reasonable, except that we may compile all of Doom Emacs
+        ## in that time, so we need to bump it for all our HM users.
+        systemd.services = mapAttrs' (user: _: {
+          name = "home-manager-${user}";
+          value.serviceConfig.TimeoutStartSec = mkForce "20m";
+        }) config.home-manager.users;
+      }
+    );
+
+in
+
+{
+  inherit specialArgsFor nixosModuleFor;
+}

--- a/nixos/nixosModuleFor.nix
+++ b/nixos/nixosModuleFor.nix
@@ -2,7 +2,7 @@
   self,
   inputs,
   lib,
-  withSystem,
+  pkgsFor,
   machines,
 }:
 
@@ -37,7 +37,7 @@ let
           inputs.home-manager.nixosModules.home-manager
         ];
 
-        nixpkgs.pkgs = withSystem config.nixpkgs.hostPlatform.system ({ pkgs, ... }: pkgs);
+        nixpkgs.pkgs = pkgsFor config.nixpkgs.hostPlatform.system;
 
         home-manager = {
           ## By default, Home Manager uses a private pkgs instance that is


### PR DESCRIPTION
It used to be embedded in `nixos/flake-parts.nix` but I think it is better that it gets an independent toplevel file `machines.nix`; that way it can be used by everything else regardless of the flake.